### PR TITLE
Feature: Add hex address encoding to outputted addresses in 1852 example

### DIFF
--- a/examples/cip-1852-keys.js
+++ b/examples/cip-1852-keys.js
@@ -11,6 +11,7 @@ import {
 const entropy = '00000000000000000000000000000000';
 const mnemonic = entropyToMnemonic(entropy);
 const accountIndex = 0;
+const keyIndex = 0;
 const networkTag = 0;
 
 // ########### Keys ###########
@@ -37,11 +38,11 @@ const accountKey = rootKey.derive(harden(1852)) // purpose
 
 // Private keys
 // derive role and address index
-const paymentPrivKey = accountKey.derive(0).derive(0).to_raw_key();
-const stakePrivKey = accountKey.derive(2).derive(0).to_raw_key();
-const dRepPrivKey = accountKey.derive(3).derive(0).to_raw_key();
-const ccColdPrivKey = accountKey.derive(4).derive(0).to_raw_key();
-const ccHotPrivKey = accountKey.derive(5).derive(0).to_raw_key();
+const paymentPrivKey = accountKey.derive(0).derive(keyIndex).to_raw_key();
+const stakePrivKey = accountKey.derive(2).derive(keyIndex).to_raw_key();
+const dRepPrivKey = accountKey.derive(3).derive(keyIndex).to_raw_key();
+const ccColdPrivKey = accountKey.derive(4).derive(keyIndex).to_raw_key();
+const ccHotPrivKey = accountKey.derive(5).derive(keyIndex).to_raw_key();
 
 // Create public keys from private keys
 const paymentPubKey = paymentPrivKey.to_public();

--- a/examples/cip-1852-keys.js
+++ b/examples/cip-1852-keys.js
@@ -60,16 +60,19 @@ const stakeCredential = Credential.from_keyhash(stakePubKey.hash());
 // Payment address
 const baseAddress = BaseAddress.new(networkTag, paymentCredential, stakeCredential);
 const paymentAddressBech32 = baseAddress.to_address().to_bech32();
+const paymentAddressHex = baseAddress.to_address().to_hex();
 
 // Stake/ Rewards address
 // Described via CIP-11 (https://github.com/cardano-foundation/CIPs/tree/master/CIP-0011)
 // Bech32 encoding prefix defined via CIP-05 (https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005)
 const stakeAddressBech32 = (RewardAddress.new(networkTag, stakeCredential)).to_address().to_bech32();
+const stakeAddressHex =(RewardAddress.new(networkTag, stakeCredential)).to_address().to_hex();
 
 // DRep ID
 // Described via CIP-105 (https://github.com/cardano-foundation/CIPs/tree/master/CIP-0105)
 // Bech32 encoding prefix defined via CIP-05 (https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005)
 const dRepIdBech32 = dRepPubKey.hash().to_bech32('drep');
+const dRepIdHex = dRepPubKey.hash().to_hex('drep');
 
 console.log('\n=== CIP-1852 Keys ===');
 console.log('From mnemonic:', mnemonic);
@@ -99,9 +102,12 @@ console.log('\n=== From keys create associated data ===');
 
 console.log('\n> Payment Address (network tag + payment pub key hash + stake pub key hash)');
 console.log('Payment Address (Bech32 encoded):', paymentAddressBech32);
+console.log('Payment Address (Hex)',paymentAddressHex)
 
 console.log('\n> Stake (rewards) Address (network tag + stake pub key hash)');
 console.log('Stake Address (Bech32 encoded):', stakeAddressBech32);
+console.log('Stake Address (Hex):', stakeAddressHex);
 
 console.log('\n> DRep ID (DRep key hash)');
 console.log('DRep ID (Bech32 encoded):', dRepIdBech32);
+console.log('DRep ID (Hex):', dRepIdHex);

--- a/examples/cip-1852-keys.js
+++ b/examples/cip-1852-keys.js
@@ -72,7 +72,7 @@ const stakeAddressHex =(RewardAddress.new(networkTag, stakeCredential)).to_addre
 // Described via CIP-105 (https://github.com/cardano-foundation/CIPs/tree/master/CIP-0105)
 // Bech32 encoding prefix defined via CIP-05 (https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005)
 const dRepIdBech32 = dRepPubKey.hash().to_bech32('drep');
-const dRepIdHex = dRepPubKey.hash().to_hex('drep');
+const dRepIdHex = dRepPubKey.hash().to_hex();
 
 console.log('\n=== CIP-1852 Keys ===');
 console.log('From mnemonic:', mnemonic);
@@ -102,7 +102,7 @@ console.log('\n=== From keys create associated data ===');
 
 console.log('\n> Payment Address (network tag + payment pub key hash + stake pub key hash)');
 console.log('Payment Address (Bech32 encoded):', paymentAddressBech32);
-console.log('Payment Address (Hex)',paymentAddressHex)
+console.log('Payment Address (Hex):', paymentAddressHex)
 
 console.log('\n> Stake (rewards) Address (network tag + stake pub key hash)');
 console.log('Stake Address (Bech32 encoded):', stakeAddressBech32);


### PR DESCRIPTION
- [x] changed address/key index to be a constant defined at the start
- [x] add hex encoded options to outputted addresses